### PR TITLE
Fix for TWIML message markup

### DIFF
--- a/app/Http/Controllers/MessagingController.php
+++ b/app/Http/Controllers/MessagingController.php
@@ -63,7 +63,7 @@ class MessagingController extends Controller
         $response = new Twiml();
         $messageBody = $NumMedia == 0 ? 'Send us an image!' : "Thanks for the $NumMedia images.";
         $message = $response->message([
-          'from' => $FromNumber,
+          'from' => $request->input('To'),
           'to' => $FromNumber
         ]);
         $message->body($messageBody);

--- a/app/Http/Controllers/MessagingController.php
+++ b/app/Http/Controllers/MessagingController.php
@@ -62,11 +62,11 @@ class MessagingController extends Controller
 
         $response = new Twiml();
         $messageBody = $NumMedia == 0 ? 'Send us an image!' : "Thanks for the $NumMedia images.";
-        $response->message([
+        $message = $response->message([
           'from' => $FromNumber,
-          'to' => $FromNumber,
-          'body' => $messageBody
+          'to' => $FromNumber
         ]);
+        $message->body($messageBody);
 
         return (string)$response;
     }

--- a/tests/Feature/IncomingSMSTest.php
+++ b/tests/Feature/IncomingSMSTest.php
@@ -62,8 +62,8 @@ class IncomingSMSTest extends TestCase
 
         $response->assertSee(
           "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" .
-          "<Response><Message from=\"+1707XXXXXXX\" to=\"+1707XXXXXXX\"" .
-          " body=\"Thanks for the 1 images.\"/></Response>");
+          "<Response><Message from=\"+1707XXXXXXX\" to=\"+1707XXXXXXX\">" .
+          "<Body>Thanks for the 1 images.</Body></Message></Response>");
     }
 
     public function testCorrectTwimlResponseWhenNoMediaIsSent()
@@ -74,8 +74,8 @@ class IncomingSMSTest extends TestCase
 
         $response->assertSee(
           "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" .
-          "<Response><Message from=\"+1707XXXXXXX\" to=\"+1707XXXXXXX\"" .
-          " body=\"Send us an image!\"/></Response>");
+          "<Response><Message from=\"+1707XXXXXXX\" to=\"+1707XXXXXXX\">" .
+          "<Body>Send us an image!</Body></Message></Response>");
     }
 
     public function testGetAllMedia()


### PR DESCRIPTION
You get a “Schema validation warning” in the Twilio debugger with the current markup. This fix formats the TWIML correctly to create a <body> element within <message>

Supporting error message
![untitled-2](https://user-images.githubusercontent.com/219298/29804807-61c29bfe-8c53-11e7-92ec-55bcf4df6be3.jpg)
